### PR TITLE
Remove libris repo reference from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
             "email": "nickolas@phpsp.org.br"
         }
     ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/researchgate/libris"
-        }
-    ],
     "require": {
         "php": "^7.4 | ^8.0 | ^8.1 | ^8.2",
         "ext-json": "*",


### PR DESCRIPTION
Now that libris has been published on Packagist, we don't need the reference anymore.